### PR TITLE
Shorten SERP titles, update name and location

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -7,10 +7,9 @@ import { generatePersonSchema } from '@/lib/schema';
 import DoctorImg from '../../public/doctor.jpg';
 
 export const metadata: Metadata = {
-  title:
-    'About PelvFix Physical Therapy – Dr. Suzanne Chedid, Pelvic Floor Therapist in Middlesex County, NJ',
+  title: 'Dr. Suzanne Chedid Fahey, Pelvic Floor Therapist',
   description:
-    'Learn about PelvFix Physical Therapy and Dr. Suzanne Chedid, a specialized pelvic floor physical therapist providing mobile, in-home care in Middlesex County, East Brunswick, and Central NJ.',
+    'Meet Dr. Suzanne Chedid Fahey, DPT — pelvic floor physical therapist providing mobile, in-home care in Middlesex County, South Brunswick, and Central NJ.',
   alternates: {
     canonical: '/about',
   },
@@ -32,7 +31,7 @@ export default function AboutPage() {
           <div className="h-full pt-4">
             <Image
               src={DoctorImg}
-              alt="Dr. Suzanne Chedid, DPT - Pelvic Floor Physical Therapist"
+              alt="Dr. Suzanne Chedid Fahey, DPT - Pelvic Floor Physical Therapist"
               className="rounded-lg rounded-tl-[15%] rounded-br-[15%] w-64 md:w-96"
               priority
             />
@@ -43,7 +42,7 @@ export default function AboutPage() {
             </h1>
             <p>
               <span className="text-primary/90 font-medium">
-                {'Dr. Suzanne Chedid '}
+                {'Dr. Suzanne Chedid Fahey '}
               </span>
               is a specialized physical therapist with a focus on pelvic floor
               rehabilitation. She earned her{' '}
@@ -55,7 +54,7 @@ export default function AboutPage() {
             </p>
             <p>
               With experience in pelvic floor, neurological, and orthopedic
-              rehabilitation in an outpatient hospital setting, Dr. Chedid
+              rehabilitation in an outpatient hospital setting, Dr. Chedid Fahey
               developed a strong foundation in treating various conditions.
               However, she found women&apos;s health to be an underserved area,
               fueling her commitment to
@@ -69,7 +68,7 @@ export default function AboutPage() {
             </p>
             <p>
               {
-                'As the owner of PelvFix and a certified Pregnancy and Postpartum Corrective Exercise Specialist (PCES), Dr. Chedid is dedicated to helping women understand and overcome pelvic floor conditions to improve their quality of life.'
+                'As the owner of PelvFix and a certified Pregnancy and Postpartum Corrective Exercise Specialist (PCES), Dr. Chedid Fahey is dedicated to helping women understand and overcome pelvic floor conditions to improve their quality of life.'
               }
             </p>
           </div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,10 +2,9 @@ import type { Metadata } from 'next';
 import ContactForm from '@/components/contactForm';
 
 export const metadata: Metadata = {
-  title:
-    'Contact – Book Mobile Pelvic Floor Physical Therapy in Middlesex County, NJ',
+  title: 'Book In-Home Pelvic Floor Therapy in NJ',
   description:
-    'Contact PelvFix Physical Therapy to book an in-home pelvic floor physical therapy session in Middlesex County, East Brunswick, and Central NJ or ask questions about our services and availability.',
+    'Contact PelvFix Physical Therapy to book an in-home pelvic floor PT session in Middlesex County, South Brunswick, or Central NJ. Call (732) 853-1055.',
   alternates: {
     canonical: '/contact',
   },

--- a/app/faqs/page.tsx
+++ b/app/faqs/page.tsx
@@ -9,10 +9,9 @@ import { FAQS } from '@/lib/data';
 import { generateFAQPageSchema } from '@/lib/schema';
 
 export const metadata: Metadata = {
-  title:
-    'FAQs – Pelvic Floor Physical Therapy Questions Answered in Middlesex County, NJ',
+  title: 'Pelvic Floor Physical Therapy FAQs',
   description:
-    'Find answers to common questions about pelvic floor physical therapy, mobile visits, pricing, scheduling, and what to expect with PelvFix Physical Therapy in Middlesex County and Central NJ.',
+    'Answers to common questions about pelvic floor physical therapy: what to expect, insurance, internal exams, and in-home visits in Middlesex County, NJ.',
   alternates: {
     canonical: '/faqs',
   },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,24 +29,22 @@ const serif = Playfair_Display({
 export const metadata: Metadata = {
   metadataBase: new URL('https://www.pelvfixpt.com'),
   title: {
-    default:
-      'PelvFix Physical Therapy - Mobile Pelvic Floor PT in Middlesex County, NJ',
-    template: '%s - PelvFix Physical Therapy',
+    default: 'In-Home Pelvic Floor Physical Therapy | Middlesex County NJ',
+    template: '%s | PelvFix',
   },
   description:
-    'Mobile pelvic floor physical therapy serving Middlesex County, East Brunswick, and Central NJ. Dr. Suzanne Chedid brings expert one-on-one care directly to your home.',
+    'Mobile pelvic floor physical therapy serving Middlesex County, South Brunswick, and Central NJ. Dr. Suzanne Chedid Fahey brings expert one-on-one care directly to your home.',
   keywords:
-    'Pelvic Floor, Physical Therapy, Health, Wellness, NJ, Women, Pelvic PT, Middlesex County, East Brunswick, in-home PT, mobile physical therapy',
+    'Pelvic Floor, Physical Therapy, Health, Wellness, NJ, Women, Pelvic PT, Middlesex County, South Brunswick, in-home PT, mobile physical therapy',
   robots: 'index, follow',
 
   openGraph: {
     type: 'website',
     url: '/',
     siteName: 'PelvFix',
-    title:
-      'PelvFix Physical Therapy - Mobile Pelvic Floor PT in Middlesex County, NJ',
+    title: 'In-Home Pelvic Floor Physical Therapy | Middlesex County NJ',
     description:
-      'Mobile pelvic floor physical therapy serving Middlesex County, East Brunswick, and Central New Jersey. Dr. Suzanne Chedid brings expert one-on-one care directly to your home.',
+      'Mobile pelvic floor physical therapy serving Middlesex County, South Brunswick, and Central New Jersey. Dr. Suzanne Chedid Fahey brings expert one-on-one care directly to your home.',
     locale: 'en_US',
     images: [
       {
@@ -59,10 +57,9 @@ export const metadata: Metadata = {
 
   twitter: {
     card: 'summary_large_image',
-    title:
-      'PelvFix Physical Therapy - Mobile Pelvic Floor PT in Middlesex County, NJ',
+    title: 'In-Home Pelvic Floor Physical Therapy | Middlesex County NJ',
     description:
-      'Mobile pelvic floor physical therapy serving Middlesex County, East Brunswick, and Central New Jersey. Dr. Suzanne Chedid brings expert one-on-one care directly to your home.',
+      'Mobile pelvic floor physical therapy serving Middlesex County, South Brunswick, and Central New Jersey. Dr. Suzanne Chedid Fahey brings expert one-on-one care directly to your home.',
     images: ['https://www.pelvfixpt.com/og-logo.jpg'],
   },
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,10 +15,11 @@ import HappyIcon from '../public/happy-icon.svg';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title:
-    'PelvFix Physical Therapy - Mobile Pelvic Floor PT in Middlesex County, NJ',
+  title: {
+    absolute: 'In-Home Pelvic Floor Physical Therapy | Middlesex County NJ',
+  },
   description:
-    'In-home pelvic floor physical therapy in Middlesex County, East Brunswick, and Central NJ. PelvFix Physical Therapy provides personalized, one-on-one care from Dr. Suzanne Chedid in the comfort of your home.',
+    'In-home pelvic floor physical therapy in Middlesex County, South Brunswick & Central NJ. One-on-one care from Dr. Suzanne Chedid Fahey in the comfort of your home.',
   alternates: {
     canonical: '/',
   },
@@ -42,10 +43,10 @@ export default function Home() {
             <h1 className="text-4xl md:text-6xl lg:text-7xl text-balance text-primary font-serif">
               Pelvic Floor Rehab & Wellness
             </h1>
-            <h2 className="text-pretty text-center md:text-lg mt-4 mb-6 max-w-[384px] mx-auto">
-              One on one, personalized care in the comfort of your home. Serving
-              Middlesex County and Central NJ.
-            </h2>
+            <p className="text-pretty text-center md:text-lg mt-4 mb-6 max-w-[384px] mx-auto">
+              One on one, personalized pelvic floor physical therapy in the
+              comfort of your home. Serving Middlesex County and Central NJ.
+            </p>
             <Button size={'lg'} className="w-full max-w-40" asChild>
               <Link href={'/contact'}>Schedule</Link>
             </Button>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,25 +4,21 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: 'https://www.pelvfixpt.com',
-      lastModified: new Date(),
-      changeFrequency: 'yearly',
+      changeFrequency: 'monthly',
       priority: 1,
     },
     {
       url: 'https://www.pelvfixpt.com/about',
-      lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: 'https://www.pelvfixpt.com/faqs',
-      lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: 'https://www.pelvfixpt.com/contact',
-      lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,
     },

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -163,7 +163,7 @@ export const FAQS = [
     id: '8',
     question: 'What areas do you serve?',
     answer: [
-      'We provide in-home physical therapy services to patients in Middlesex County, and surrounding areas (approximately 30 minutes from East Brunswick, NJ). If you are outside of our service area, feel free to reach out to see if we can accommodate your location.',
+      'We provide in-home physical therapy services to patients in Middlesex County, and surrounding areas (approximately 30 minutes from South Brunswick, NJ). If you are outside of our service area, feel free to reach out to see if we can accommodate your location.',
     ],
   },
   {

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -10,6 +10,7 @@ export function generateWebSiteSchema() {
     '@type': 'WebSite',
     '@id': `${BASE_URL}/#website`,
     name: SITE_NAME,
+    alternateName: BUSINESS_NAME,
     url: BASE_URL,
     publisher: {
       '@id': `${BASE_URL}/#organization`,
@@ -23,17 +24,22 @@ export function generateOrganizationSchema() {
     '@type': 'Organization',
     '@id': `${BASE_URL}/#organization`,
     name: BUSINESS_NAME,
+    alternateName: SITE_NAME,
     url: BASE_URL,
     logo: `${BASE_URL}/og-logo.jpg`,
     image: `${BASE_URL}/og-logo.jpg`,
     description:
-      'Mobile pelvic floor physical therapy serving Middlesex County and Central NJ. Dr. Suzanne Chedid brings expert one-on-one care directly to your home.',
+      'Mobile pelvic floor physical therapy serving Middlesex County and Central NJ. Dr. Suzanne Chedid Fahey brings expert one-on-one care directly to your home.',
     telephone: '+1-732-853-1055',
     email: 'info@pelvfixpt.com',
     areaServed: [
       {
         '@type': 'AdministrativeArea',
         name: 'Middlesex County, NJ',
+      },
+      {
+        '@type': 'City',
+        name: 'South Brunswick, NJ',
       },
       {
         '@type': 'AdministrativeArea',
@@ -76,7 +82,7 @@ export function generateOrganizationSchema() {
     sameAs: [SOCIAL_LINKS.instagram, SOCIAL_LINKS.facebook, SOCIAL_LINKS.tiktok],
     founder: {
       '@type': 'Person',
-      name: 'Dr. Suzanne Chedid',
+      name: 'Dr. Suzanne Chedid Fahey',
       jobTitle: 'Doctor of Physical Therapy',
     },
     aggregateRating: {
@@ -94,14 +100,14 @@ export function generatePersonSchema() {
     '@context': 'https://schema.org',
     '@type': 'Person',
     '@id': `${BASE_URL}/about#person`,
-    name: 'Dr. Suzanne Chedid',
+    name: 'Dr. Suzanne Chedid Fahey',
     givenName: 'Suzanne',
-    familyName: 'Chedid',
+    familyName: 'Chedid Fahey',
     honorificPrefix: 'Dr.',
     honorificSuffix: 'DPT',
     jobTitle: 'Pelvic Floor Physical Therapist',
     description:
-      'Dr. Suzanne Chedid is a specialized pelvic floor physical therapist and certified Pregnancy and Postpartum Corrective Exercise Specialist (PCES) providing mobile, in-home care in Middlesex County and Central NJ.',
+      'Dr. Suzanne Chedid Fahey is a specialized pelvic floor physical therapist and certified Pregnancy and Postpartum Corrective Exercise Specialist (PCES) providing mobile, in-home care in Middlesex County and Central NJ.',
     image: `${BASE_URL}/doctor.jpg`,
     url: `${BASE_URL}/about`,
     worksFor: {


### PR DESCRIPTION

- Rewrite all page titles to under 60 chars so Google stops truncating them; front-load "pelvic floor physical therapy" keywords and shorten the title template suffix to "| PelvFix"
- Trim meta descriptions to ~155 chars; add phone number to contact
- Add alternateName cross-references between WebSite/Organization schema
- Update Dr. Suzanne Chedid to Dr. Suzanne Chedid Fahey site-wide (patient testimonial quote left verbatim)
- Update East Brunswick to South Brunswick in copy, metadata, and schema
- Convert hero subtitle from h2 to p and include target keyword
- Remove sitemap lastModified (was new Date() on every build)